### PR TITLE
Fix chat form reload

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
           <!-- End of messages -->
           <div></div>
         </div>
-        <form class="border-t pt-2 mt-2">
+        <form id="chat-form" class="border-t pt-2 mt-2">
           <div class="flex gap-2">
             <textarea placeholder="Type your message..."
               class="min-h-10 flex-1 resize-none bg-white px-3 py-2 rounded-md border border-gray-300 focus:outline-none focus:ring-2 focus:ring-[#a0aeae] text-gray-900"></textarea>

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -1,6 +1,7 @@
 document.addEventListener('DOMContentLoaded', function () {
   const openBtn = document.getElementById('open-chatbot-btn')
   const modal = document.getElementById('chatbot-modal')
+  const chatForm = document.getElementById('chat-form')
 
   if (openBtn && modal) {
     openBtn.addEventListener('click', function () {
@@ -14,6 +15,13 @@ document.addEventListener('DOMContentLoaded', function () {
       if (e.target.closest('#close-chatbot-btn')) {
         modal.classList.add('hidden') // Add the 'hidden' class to hide the modal
       }
+    })
+  }
+
+  if (chatForm) {
+    chatForm.addEventListener('submit', function (e) {
+      e.preventDefault()
+      // TODO: handle submitting message to the chatbot
     })
   }
 })


### PR DESCRIPTION
## Summary
- prevent chat form from reloading the page on submit
- expose chat-form element to JS for future functionality

## Testing
- `npm run build` *(fails: 403 Forbidden when downloading @tailwindcss/cli)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_683fc660f8788326b636a9027d10135c