### PR TITLE
Add RAG console assistant

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,13 @@
 {
   "scripts": {
-    "build": "npx @tailwindcss/cli -i ./src/styles/style.css -o ./dist/output.css --watch"
+    "build": "npx @tailwindcss/cli -i ./src/styles/style.css -o ./dist/output.css --watch",
+    "rag": "node rag.js"
   },
   "dependencies": {
     "@tailwindcss/postcss": "^4.1.8",
     "postcss": "^8.5.4",
-    "tailwindcss": "^4.1.8"
+    "tailwindcss": "^4.1.8",
+    "openai": "^4.36.1",
+    "pdf-parse": "^1.1.1"
   }
 }

--- a/rag.js
+++ b/rag.js
@@ -1,0 +1,87 @@
+const fs = require('fs');
+const pdfParse = require('pdf-parse');
+const { OpenAI } = require('openai');
+require('dotenv').config();
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+async function loadPDF(path) {
+  const dataBuffer = fs.readFileSync(path);
+  const data = await pdfParse(dataBuffer);
+  return data.text;
+}
+
+function splitText(text, chunkSize = 1000, overlap = 200) {
+  const words = text.split(/\s+/);
+  const chunks = [];
+  for (let i = 0; i < words.length; i += chunkSize - overlap) {
+    chunks.push(words.slice(i, i + chunkSize).join(' '));
+  }
+  return chunks;
+}
+
+async function embedTexts(texts) {
+  const resp = await openai.embeddings.create({
+    model: 'text-embedding-ada-002',
+    input: texts
+  });
+  return resp.data.map(r => r.embedding);
+}
+
+function cosine(a, b) {
+  let dot = 0, na = 0, nb = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    na += a[i] * a[i];
+    nb += b[i] * b[i];
+  }
+  return dot / (Math.sqrt(na) * Math.sqrt(nb));
+}
+
+async function createStore(pdfPath) {
+  const text = await loadPDF(pdfPath);
+  const chunks = splitText(text);
+  const embeddings = await embedTexts(chunks);
+  return chunks.map((c, i) => ({ text: c, embedding: embeddings[i] }));
+}
+
+async function answerQuestion(store, question, k = 3) {
+  const [qEmbedding] = await embedTexts([question]);
+  const top = store
+    .map(item => ({ text: item.text, score: cosine(item.embedding, qEmbedding) }))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, k);
+  const context = top.map(t => t.text).join('\n---\n');
+
+  const chat = await openai.chat.completions.create({
+    model: 'gpt-3.5-turbo',
+    messages: [
+      { role: 'system', content: 'Answer questions using the provided context.' },
+      { role: 'user', content: `Context:\n${context}\nQuestion: ${question}` }
+    ]
+  });
+  return chat.choices[0].message.content.trim();
+}
+
+(async () => {
+  if (!process.argv[2]) {
+    console.error('Usage: node rag.js <path-to-pdf>');
+    process.exit(1);
+  }
+  const store = await createStore(process.argv[2]);
+  console.log('Type your question (or "exit" to quit)');
+  const rl = require('readline').createInterface({ input: process.stdin, output: process.stdout });
+  const ask = () => {
+    rl.question('> ', async q => {
+      if (q.toLowerCase() === 'exit') return rl.close();
+      try {
+        const answer = await answerQuestion(store, q);
+        console.log(answer);
+      } catch (e) {
+        console.error('Error:', e.message);
+      }
+      ask();
+    });
+  };
+  ask();
+})();

--- a/readme.md
+++ b/readme.md
@@ -61,3 +61,17 @@ To run the project, follow these steps:
    npx live-server
    ```
 7. Open your browser and navigate to `http://localhost:5500` (or the port specified by your local server).
+
+## Console PDF Assistant
+
+The repository now includes a simple Retrieval Augmented Generation (RAG) script for querying a local PDF with OpenAI models.
+
+1. Create a `.env` file in the project root containing your OpenAI API key:
+   ```bash
+   echo "OPENAI_API_KEY=your-key" > .env
+   ```
+2. Run the assistant and provide a path to a PDF:
+   ```bash
+   npm run rag example.pdf
+   ```
+3. Ask questions in the console. Type `exit` to quit.


### PR DESCRIPTION
## Summary
- add script `rag.js` that loads a PDF, builds embeddings and answers questions using OpenAI
- include new dependencies and npm script in `package.json`
- document how to use the console PDF assistant in `readme.md`

## Testing
- `npm run build` *(fails: 403 Forbidden from npm registry)*
- `npm run rag example.pdf` *(fails: Cannot find module 'pdf-parse')*

------
https://chatgpt.com/codex/tasks/task_e_683fd88029308326b7f7bee7645e6af8